### PR TITLE
Add Speccy OpenAPI linter Git hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,11 @@ repos:
     hooks:
       - id: prettier
         name: Prettier
+
+  - repo: local
+    hooks:
+      - id: dockerfile-provides-entrypoint
+        name: Speccy
+        language: docker_image
+        entry: wework/speccy:latest lint
+        files: 'specs/.*\.(yml|json|yaml)$'


### PR DESCRIPTION
Add [Speccy](http://speccy.io) ([wework/speccy](https://github.com/wework/speccy/)) as a Git hook to lint [OpenAPI](https://swagger.io) (formerly Swagger) definitions.

Because there is no formal pre-commit support, we leverage Docker containers to run Speccy. Also, because the tool runs against all YAML and JSON files, regardless of whether they are OpenAPI/Swagger files, we only lint files found in the `specs` directory.

[![asciicast](https://asciinema.org/a/308584.svg)](https://asciinema.org/a/308584)

Because this hook runs in a Docker container, it suffers from the same issue outlined at ShahradR/cfn-template#2. To make this hook work, it's best to run it using WSL2 with the [Docker WSL2 based engine](https://docs.docker.com/docker-for-windows/wsl-tech-preview/), outside a development container.